### PR TITLE
Remove core and add storage to standards track categories

### DIFF
--- a/XIPs/xip-0-purpose-process.md
+++ b/XIPs/xip-0-purpose-process.md
@@ -26,7 +26,7 @@ There are three major category of XIPs, as well as more specific subcategories:
   - **Core**: includes proposals for rules and behavior around message relay by nodes, node incentive strategies, and backwards-incompatible changes that require a consensus fork
   - **Network**: includes networking specifications and proposals around how nodes communicate and interoperate
   - **Interface**: includes client API/RPC specifications and improvements to how clients interact with the network
-  - **Storage**: includes specifications and proposals for private persistent storage of messages by or on behalf of clients
+  - **Storage**: includes specifications and proposals for persistent storage of messages by or on behalf of clients
   - **XRC** (*XMTP Request for Comment*): includes application-level standards and conventions, including message payload formats and applications
 - A **Process XIP** describes a process surrounding XMTP, or proposes changes to an existing process. They may propose an implementation, but not to XMTP's codebase; they often require community consensus; unlike Informational XIPs, they are more than recommendations, and users are typically not free to ignore them.
 - An **Informational XIP** provides general guidelines or information to the XMTP community, but does not propose a new feature. Informational XIPs do not necessarily represent a XMTP community consensus or recommendation, so users and implementors are free to ignore Informational XMTP or follow their advice.


### PR DESCRIPTION
Discussed [here](https://github.com/xmtp/XIPs/pull/2#discussion_r813086745).