### PR TITLE
XRC-9: Composite content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ The goal of the XIP project is to document standardized protocols for XMTP clien
 
 ## Index of proposals
 
+### Standards track
+
 | ID | Title | Status |
 | -- | -- | -- |
 | 0 | [XIP Purpose, Process, & Guidelines](./XIPs/xip-0-purpose-process.md) | Living |
 | 5 | [Message content types](./XIPs/xip-5-message-content-types.md) | Final |
+
+### XRCs
+
+| ID | Title | Status |
+| -- | -- | -- |
+| 9 | [Composite content type](./XIPs/xip-composite-content-type.md) | Final |

--- a/README.md
+++ b/README.md
@@ -24,13 +24,8 @@ The goal of the XIP project is to document standardized protocols for XMTP clien
 
 ### Standards track
 
-| ID | Title | Status |
-| -- | -- | -- |
-| 0 | [XIP Purpose, Process, & Guidelines](./XIPs/xip-0-purpose-process.md) | Living |
-| 5 | [Message content types](./XIPs/xip-5-message-content-types.md) | Final |
-
-### XRCs
-
-| ID | Title | Status |
-| -- | -- | -- |
-| 9 | [Composite content type](./XIPs/xip-composite-content-type.md) | Final |
+| ID | Title | Type | Status |
+| -- | -- | -- | -- |
+| 0 | [XIP Purpose, Process, & Guidelines](./XIPs/xip-0-purpose-process.md) | Process | Living |
+| 5 | [Message content types](./XIPs/xip-5-message-content-types.md) | Interface | Final |
+| 9 | [Composite content type](./XIPs/xip-9-composite-content-type.md) | XRC | Final |

--- a/XIPs/xip-0-purpose-process.md
+++ b/XIPs/xip-0-purpose-process.md
@@ -80,7 +80,9 @@ XIPs should be written in [markdown](https://github.com/adam-p/markdown-here/wik
 
 Each XIP must begin with an [RFC 822](https://www.ietf.org/rfc/rfc822.txt) style header preamble, formatted as a bulleted list. This header is also termed ["front matter" by Jekyll](https://jekyllrb.com/docs/front-matter/). The headers must appear in the following order.
 
-`title`: *The XIP title is a few words, not a complete sentence. An ID [XIP-n] will be added by an editor when the XIP is considered Final.*
+`xip`: *An ID will be added by an editor when the XIP is considered Final.* (The ID will correspond with its pull request number.)
+
+`title`: *The XIP title is a few words, not a complete sentence.*
 
 `description`: *Description is one full (short) sentence*
 

--- a/XIPs/xip-5-message-content-types.md
+++ b/XIPs/xip-5-message-content-types.md
@@ -1,5 +1,5 @@
 ---
-title: XIP-5: Message content types
+title: XIP-5 Message content types
 description: Interoperable framework for supporting different types of content
 author: Martin Kobetic (@mkobetic), Nick Molnar (@neekolas)
 status: Final

--- a/XIPs/xip-5-message-content-types.md
+++ b/XIPs/xip-5-message-content-types.md
@@ -1,5 +1,6 @@
 ---
-title: XIP-5: Message content types
+xip: 5
+title: Message content types
 description: Interoperable framework for supporting different types of content
 author: Martin Kobetic (@mkobetic), Nick Molnar (@neekolas)
 status: Final

--- a/XIPs/xip-5-message-content-types.md
+++ b/XIPs/xip-5-message-content-types.md
@@ -1,5 +1,5 @@
 ---
-title: XIP-5 Message content types
+title: XIP-5: Message content types
 description: Interoperable framework for supporting different types of content
 author: Martin Kobetic (@mkobetic), Nick Molnar (@neekolas)
 status: Final

--- a/XIPs/xip-9-composite-content-type.md
+++ b/XIPs/xip-9-composite-content-type.md
@@ -1,8 +1,8 @@
 ---
-title: XRC-9 Composite content type
+title: XRC-9: Composite content type
 description: Generic content type for multi-part content
 author: Martin Kobetic (@mkobetic)
-status: Draft
+status: Final
 type: Standards Track
 category: XRC
 created: 2022-04-07
@@ -10,7 +10,7 @@ created: 2022-04-07
 
 ## Abstract
 
-Based on XIP-5 this XRC proposes a new content type `xtmp.org/composite:1.0` for multi-part messages where the parts can be of any content type and the composite parts can be arbitrarily nested.
+Based on [XIP-5](xip-5-message-content-types.md) this XRC proposes a new content type `xtmp.org/composite:1.0` for multi-part messages where the parts can be of any content type and the composite parts can be arbitrarily nested.
 
 ## Motivation
 

--- a/XIPs/xip-9-composite-content-type.md
+++ b/XIPs/xip-9-composite-content-type.md
@@ -1,5 +1,6 @@
 ---
-title: XRC-9: Composite content type
+xip: 9
+title: Composite content type
 description: Generic content type for multi-part content
 author: Martin Kobetic (@mkobetic)
 status: Final

--- a/XIPs/xip-9-composite-content-type.md
+++ b/XIPs/xip-9-composite-content-type.md
@@ -1,5 +1,5 @@
 ---
-title: Composite content type
+title: XRC-9 Composite content type
 description: Generic content type for multi-part content
 author: Martin Kobetic (@mkobetic)
 status: Draft

--- a/XIPs/xip-composite-content-type.md
+++ b/XIPs/xip-composite-content-type.md
@@ -14,7 +14,7 @@ Based on XIP-5 this XRC proposes a new content type `xtmp.org/composite:1.0` for
 
 ## Motivation
 
-Combining different kinds of content in a single messages seems obviously useful. Providing a generic facility to do that (similar to the MIME multipart content types) could satisfy some usecases, although more specific types designed to support particular use-cases may prove more popular in the long run. Especially since more specialized solutions will be easier to use (e.g. may infer content type rather then requiring content type IDs explicitly), and provide additional facitlities (e.g. provide hints about proper presentation of the content). Even if this generic type does not end up being widely used, it will also serve as an educational tool for future content type authors.
+Combining different kinds of content in a single messages seems obviously useful. Providing a generic facility to do that (similar to the MIME multipart content types) could satisfy some use-cases, although more specific types designed to support particular use-cases may prove more popular in the long run. Especially since more specialized solutions will be easier to use (e.g. may infer content type rather then requiring content type IDs explicitly), and provide additional facilities (e.g. provide hints about proper presentation of the content). Even if this generic type does not end up being widely used, it will also serve as an educational tool for future content type authors.
 
 ## Specification
 
@@ -40,7 +40,7 @@ const content = { parts: [
         { type: ContentTypeText, content: 'four' }]}]}
 ```
 
-This type of content SHALL be identied with following `ContentTypeId`
+This type of content SHALL be identified with following `ContentTypeId`
 
 ```ts
 export const ContentTypeComposite = new ContentTypeId({

--- a/XIPs/xip-composite-content-type.md
+++ b/XIPs/xip-composite-content-type.md
@@ -1,0 +1,83 @@
+---
+title: Composite content type
+description: Generic content type for multi-part content
+author: Martin Kobetic (@mkobetic)
+status: Draft
+type: Standards Track
+category: XRC
+created: 2022-04-07
+---
+
+## Abstract
+
+Based on XIP-5 this XRC proposes a new content type `xtmp.org/composite:1.0` for multi-part messages where the parts can be of any content type and the composite parts can be arbitrarily nested.
+
+## Motivation
+
+Combining different kinds of content in a single messages seems obviously useful. Providing a generic facility to do that (similar to the MIME multipart content types) could satisfy some usecases, although more specific types designed to support particular use-cases may prove more popular in the long run. Especially since more specialized solutions will be easier to use (e.g. may infer content type rather then requiring content type IDs explicitly), and provide additional facitlities (e.g. provide hints about proper presentation of the content). Even if this generic type does not end up being widely used, it will also serve as an educational tool for future content type authors.
+
+## Specification
+
+Composite content MUST be structured to satisfy the type `Composite` as follows
+
+```ts
+export type Composite =
+  | {
+      type: ContentTypeId
+      content: any
+    }
+  | { parts: Composite[] }
+```
+
+This allows for arbitrarily deep tree structure where the leaves are the actual content of arbitrary content type. For example
+
+```ts
+const content = { parts: [
+    { type: ContentTypeText, content: 'one' },
+    { parts: [
+        { type: ContentTypeText, content: 'two' },
+        { parts: [{ type: ContentTypeText, content: 'three' }] },
+        { type: ContentTypeText, content: 'four' }]}]}
+```
+
+This type of content SHALL be identied with following `ContentTypeId`
+
+```ts
+export const ContentTypeComposite = new ContentTypeId({
+  authorityId: 'xmtp.org',
+  typeId: 'composite',
+  versionMajor: 1,
+  versionMinor: 0,
+})
+```
+
+The codec, `CompositeCodec`, SHALL use protobuf for encoding of the `Composite` structure. This allows for leveraging the `EncodedContent` type already defined by the protocol and consequently seamless reuse of other codecs to handle the specific content types carried by the Composite. The protobuf definition of the encoded content SHALL be as follows:
+
+```protobuf
+message Composite {
+  message Part {
+    oneof element {
+      EncodedContent part = 1;
+      Composite composite = 2;
+    }
+  }
+
+  repeated Part parts = 1;
+}
+```
+
+## Rationale
+
+It is unclear at this point what particular aspects of multipart content will be relevant in practice, consequently this initial proposal is about as simple as it gets. Subsequent revisions can add more features, although there is some expectation that more specialized content types will be preferred for specific use-cases. Protobuf has been chosen to keep the implementation simple, which should support the educational goals of this proposal.
+
+## Reference Implementation
+
+The reference implementation is intended to be part of the XMTP SDK. [https://github.com/xmtp/xmtp-js/pull/96](https://github.com/xmtp/xmtp-js/pull/96). The codec will not be part of the default Client setup, clients wishing to employ this codec SHOULD register this codec explicitly.
+
+## Security Considerations
+
+This content type allows transmitting arbitrary and therefore potentially dangerous types of content. Complex decoding or presentation logic can trigger undesirable or dangerous behavior in the receiving client. Security considerations associated with all of the content types used as parts of a Composite apply to the Composite as well.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Based on XIP-5 this XRC proposes a new content type `xtmp.org/composite:1.0` for multi-part messages where the parts can be of any content type and the composite parts can be arbitrarily nested.

Reference implementation https://github.com/xmtp/xmtp-js/pull/96