### PR TITLE
Update XIP-21 to Last call status

### DIFF
--- a/XIPs/xip-21-transaction-reference-content-type.md
+++ b/XIPs/xip-21-transaction-reference-content-type.md
@@ -2,7 +2,7 @@
 title: On-chain transaction reference content type
 description: Provides an on-chain transaction hash or ID sent as a message.
 author: @rygine (Ry Racherbaumer), @lourou (Louis Rouffineau), @nmalzieu (Noé Malzieu), @galligan (Matt Galligan), @nakajima (Pat Nakajima), @yash-luna (Yash Lunagaria)
-status: Review
+status: Last call
 type: Standards
 category: XRC
 created: 2024-01-26


### PR DESCRIPTION
Moving XIP to Last Call status after incorporating feedback from community.

After 14 days in Last Call status with no normative changes, XIP will move into Final status.