### PR TITLE
Add stalebot to help moderate stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: "Mark stale issues and PRs"
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily
+  workflow_dispatch:     # Allows manual run too
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 182            # ~6 months
+          days-before-close: 7
+          stale-pr-message: >
+            There has been no activity on this issue for six months. It will be closed in 7 days if there is no new activity.
+          close-pr-message: >
+            Closed due to inactivity. If still interested, please reopen and continue the discussion.
+          stale-issue-message: ""           # You can leave issues alone
+          close-issue-message: ""
+          only-pr-labels: ""
+          stale-pr-label: stale
+          exempt-pr-labels: keep-open


### PR DESCRIPTION
### Configure GitHub Actions workflow to automatically close pull requests after 182 days of inactivity
Adds a new GitHub Actions workflow that manages pull request lifecycle through the `actions/stale@v9` action. The workflow:
* Marks PRs as stale after 182 days of inactivity and adds a `stale` label
* Closes stale PRs after an additional 7 days without activity
* Excludes PRs with `keep-open` label from being marked as stale
* Runs on a daily schedule at midnight
* Configured in [stale.yml](https://github.com/xmtp/XIPs/pull/109/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894)

#### 📍Where to Start
Review the workflow configuration in [stale.yml](https://github.com/xmtp/XIPs/pull/109/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894) which contains all the settings for the stale PR automation.

----

_[Macroscope](https://app.macroscope.com) summarized f23f9ca._