### PR TITLE
Update v2 read-only date in XIP-53: XMTP V2 deprecation

### DIFF
--- a/XIPs/xip-53-v2-deprecation.md
+++ b/XIPs/xip-53-v2-deprecation.md
@@ -26,9 +26,9 @@ Now that XMTP V3 is fully featured and developer-ready, it’s the ideal time to
 
 **Developers should upgrade to XMTP V3**, moving off any V2-compatible versions of the XMTP SDK. We recommend always updating your app to the latest SDK version to ensure you benefit from the most recent stable release.
 
-### April 1, 2025
+### May 1, 2025
 
-**The XMTP V2 read-only transition period begins.** On every Tuesday and Thursday in April 2025 (1, 3, 8, 10, 15, 17, 22, 24, and 29), the XMTP V2 network will be in read-only mode during the following times:
+**The XMTP V2 read-only transition period begins.** On every Tuesday and Thursday in May 2025 (1, 6, 8, 13, 15, 20, 22, 27, and 29), the XMTP V2 network will be in read-only mode during the following times:
 
 North America
 
@@ -80,7 +80,7 @@ This read-only transition period will also help developers identify some of the 
 
 - A developer published an agent/bot using a version of the XMTP SDK that includes the `enableV3` flag set to `true`, and forgot about the agent. The agent experience will break when XMTP V2 is in read-only mode.
 
-### May 1, 2025
+### June 23, 2025
 
 **At 07:00 PM PDT, XMTP V2 will be permanently set to read-only mode.** No more writes to the V2 network will be allowed.
 
@@ -102,4 +102,4 @@ To learn more, see [Messaging security properties with XMTP](https://docs.xmtp.o
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
### Extend XMTP V2 deprecation timeline by moving read-only transition from April 1, 2025 to May 1, 2025 and permanent read-only mode from May 1, 2025 to June 23, 2025
This change updates the deprecation schedule in [XIPs/xip-53-v2-deprecation.md](https://github.com/xmtp/XIPs/pull/111/files#diff-2c0e44cb2642dfd8d7c1ee29a5eece57af80d6d5c15bab07ea412738575e2d5e) by extending the timeline by approximately 7 weeks. The read-only transition period start date moves from April 1, 2025 to May 1, 2025, the Tuesday and Thursday read-only periods shift from April 2025 dates to May 2025 dates (1, 6, 8, 13, 15, 20, 22, 27, and 29), and the permanent read-only mode date changes from May 1, 2025 to June 23, 2025.

#### 📍Where to Start
Start with the timeline section in [XIPs/xip-53-v2-deprecation.md](https://github.com/xmtp/XIPs/pull/111/files#diff-2c0e44cb2642dfd8d7c1ee29a5eece57af80d6d5c15bab07ea412738575e2d5e) where the deprecation dates are specified.

----

_[Macroscope](https://app.macroscope.com) summarized b0f43a8._