### PR TITLE
Update XIP-69 file name to match numbering

### DIFF
--- a/XIPs/xip-69-message-retention-and-expiry.md
+++ b/XIPs/xip-69-message-retention-and-expiry.md
@@ -6,7 +6,7 @@ status: Living
 type: Process
 author: Martin Kysel (@mkysel)
 created: 2025-06-24
-updated: 2025-06-24
+updated: 2025-06-30
 ---
 
 ## Summary


### PR DESCRIPTION
### Rename XIP-66 file to XIP-69 to match numbering in XIPs directory
Renames the XIP file from `xip-66-message-retention-and-expiry.md` to `xip-69-message-retention-and-expiry.md` and updates the metadata date from 2025-06-24 to 2025-06-30 in [XIPs/xip-69-message-retention-and-expiry.md](https://github.com/xmtp/XIPs/pull/113/files#diff-bb7e7c16f788eb0a5c6bcd9ee78468075dba075c3170c7c0c5fe30c20f54841f).

#### 📍Where to Start
Start with the renamed file [XIPs/xip-69-message-retention-and-expiry.md](https://github.com/xmtp/XIPs/pull/113/files#diff-bb7e7c16f788eb0a5c6bcd9ee78468075dba075c3170c7c0c5fe30c20f54841f) to verify the file name change and metadata update.

----

_[Macroscope](https://app.macroscope.com) summarized a3e1c42._