### PR TITLE
XIP-42 in final status

### DIFF
--- a/XIPs/xip-42-universal-allow-block-preferences.md
+++ b/XIPs/xip-42-universal-allow-block-preferences.md
@@ -3,11 +3,11 @@ xip: 42
 title: Universal 'allow' and 'block' preferences
 description:
 author: Saul Carlin (@saulmc), Nick Molnar (@neekolas), Naomi Plasterer (@nplasterer), Ry Racherbaumer (@rygine)
-discussions-to: <https://community.xmtp.org/t/xip-42-universal-allow-and-block-preferences/544>
-status: Draft
+status: Final
 type: Standards
 category: XRC
 created: 2024-02-14
+implementation: https://docs.xmtp.org/chat-apps/user-consent/user-consent
 ---
 
 ## Abstract


### PR DESCRIPTION
### Mark XIP-42 as Final and update XIPs/xip-42-universal-allow-block-preferences.md with implementation link for final status
Update [XIPs/xip-42-universal-allow-block-preferences.md](https://github.com/xmtp/XIPs/pull/121/files#diff-f39782cc01e9299a7f7f261c8f7af724460a4903ca828412321dd132d8ff81e3) to reflect final status. The change removes the `discussions-to` line, sets `status` to `Final`, and adds an `implementation` link to https://docs.xmtp.org/chat-apps/user-consent/user-consent.

#### 📍Where to Start
Start with the header metadata in [XIPs/xip-42-universal-allow-block-preferences.md](https://github.com/xmtp/XIPs/pull/121/files#diff-f39782cc01e9299a7f7f261c8f7af724460a4903ca828412321dd132d8ff81e3) to review the status change and added implementation link.

----

_[Macroscope](https://app.macroscope.com) summarized 24d28ae._