### PR TITLE
XIP-50 to final, add impl link

### DIFF
--- a/XIPs/xip-50-multiple-remote-attachments-content-type.md
+++ b/XIPs/xip-50-multiple-remote-attachments-content-type.md
@@ -3,10 +3,11 @@ xip: 50
 title: Multiple remote attachments content type
 description: Content type for multiple remote attachments
 author: Cameron Voell (@cameronvoell)
-status: Review
+status: Final
 type: Standards
 category: XRC
 created: 2025-01-28
+implementation: https://docs.xmtp.org/chat-apps/content-types/attachments#support-multiple-remote-attachments-of-any-size
 ---
 
 ## Abstract


### PR DESCRIPTION
### Mark XIP-50 as Final and add implementation link in XIPs/xip-50-multiple-remote-attachments-content-type.md to document support for multiple remote attachments of any size
This change updates the XIP front-matter to reflect its finalization and includes a link to the implementation documentation.

- Change `status` from `Review` to `Final` in [xip-50-multiple-remote-attachments-content-type.md](https://github.com/xmtp/XIPs/pull/124/files#diff-08bb670a0662464c9bc127e2edd4292f02b7ecaf99b1b17b1df4de118cb1ed21)
- Add `implementation` field with a URL to documentation for supporting multiple remote attachments of any size in [xip-50-multiple-remote-attachments-content-type.md](https://github.com/xmtp/XIPs/pull/124/files#diff-08bb670a0662464c9bc127e2edd4292f02b7ecaf99b1b17b1df4de118cb1ed21)

#### 📍Where to Start
Start with the front-matter in [XIPs/xip-50-multiple-remote-attachments-content-type.md](https://github.com/xmtp/XIPs/pull/124/files#diff-08bb670a0662464c9bc127e2edd4292f02b7ecaf99b1b17b1df4de118cb1ed21).

----

_[Macroscope](https://app.macroscope.com) summarized 0abff87._