### PR TITLE
XIP-47 to final status

### DIFF
--- a/XIPs/xip-47-group-chat-permissions.md
+++ b/XIPs/xip-47-group-chat-permissions.md
@@ -3,10 +3,11 @@ xip: 47
 title: Group Chat Permissions
 description: This proposal describes a simple, flexible, updatable group chat permissions system.
 author: Cameron Voell (@cameronvoell), Eleanor Hofstedt (@eleanorhofstedt)
-status: Review
+status: Final
 type: Standards
 category: Core
 created: 2024-05-07
+implementation: https://docs.xmtp.org/chat-apps/core-messaging/group-permissions
 ---
 
 ## Abstract


### PR DESCRIPTION
### Set XIP-47 to Final and add implementation URL in [XIPs/xip-47-group-chat-permissions.md](https://github.com/xmtp/XIPs/pull/126/files#diff-5e8935d37662ce15567f04a6be5c76abaadc7657b81363cb9825f305b403609a)
Update the XIP front-matter in [XIPs/xip-47-group-chat-permissions.md](https://github.com/xmtp/XIPs/pull/126/files#diff-5e8935d37662ce15567f04a6be5c76abaadc7657b81363cb9825f305b403609a) by changing `status` from `Review` to `Final` and adding an `implementation` URL field pointing to the docs.

#### 📍Where to Start
Start with the front-matter changes at the top of [XIPs/xip-47-group-chat-permissions.md](https://github.com/xmtp/XIPs/pull/126/files#diff-5e8935d37662ce15567f04a6be5c76abaadc7657b81363cb9825f305b403609a).

----

_[Macroscope](https://app.macroscope.com) summarized 835f764._