### PR TITLE
XIP-15 to final, impl link

### DIFF
--- a/XIPs/xip-15-attachment-content-type.md
+++ b/XIPs/xip-15-attachment-content-type.md
@@ -3,10 +3,11 @@ xip: 15
 title: Attachment Content Type
 description: Content type for basic attachments
 author: Pat Nakajima
-status: Review
-type: Standards Track
+status: Final
+type: Standards
 category: XRC
 created: 2023-02-15
+implementation: https://docs.xmtp.org/chat-apps/content-types/attachments#support-attachments-smaller-than-1mb
 ---
 
 ## Abstract


### PR DESCRIPTION
### Mark XIP-15 as Final and add implementation link for attachment content type in [XIPs/xip-15-attachment-content-type.md](https://github.com/xmtp/XIPs/pull/127/files#diff-8c46b35da8bbf8790d6952d28008179493a269f31de12abdf59e6a980225df09)
This change updates the front-matter of the XIP-15 document.

- Set `status` to `Final` in [XIPs/xip-15-attachment-content-type.md](https://github.com/xmtp/XIPs/pull/127/files#diff-8c46b35da8bbf8790d6952d28008179493a269f31de12abdf59e6a980225df09)
- Set `type` to `Standards` in [XIPs/xip-15-attachment-content-type.md](https://github.com/xmtp/XIPs/pull/127/files#diff-8c46b35da8bbf8790d6952d28008179493a269f31de12abdf59e6a980225df09)
- Add `implementation` link to https://docs.xmtp.org/chat-apps/content-types/attachments#support-attachments-smaller-than-1mb in [XIPs/xip-15-attachment-content-type.md](https://github.com/xmtp/XIPs/pull/127/files#diff-8c46b35da8bbf8790d6952d28008179493a269f31de12abdf59e6a980225df09)

#### 📍Where to Start
Start with the front-matter changes in [XIPs/xip-15-attachment-content-type.md](https://github.com/xmtp/XIPs/pull/127/files#diff-8c46b35da8bbf8790d6952d28008179493a269f31de12abdf59e6a980225df09).

----

_[Macroscope](https://app.macroscope.com) summarized 4861585._