### PR TITLE
XIP-74: Move status to last call

### DIFF
--- a/XIPs/xip-74-welcome-pointers.md
+++ b/XIPs/xip-74-welcome-pointers.md
@@ -4,7 +4,7 @@ title: Welcome pointers
 description: Implementation of welcome pointers to reduce data sent to and stored by servers
 author: Tyler Hawkes (@tylerhawkes)
 discussions-to: https://community.xmtp.org/t/xip-74-welcome-pointers/1211
-status: Review
+status: Last Call
 type: Standards
 category: Interface
 created: 2025-09-25


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update XIP-74 status to Last Call in [xip-74-welcome-pointers.md](https://github.com/xmtp/XIPs/pull/132/files#diff-a1647e80caac12654d8e8b8f824d03d83915ba5d6b72098c41f1dd371bbc267c) to reflect move to last call
Change the `status` field from `Review` to `Last Call` in [xip-74-welcome-pointers.md](https://github.com/xmtp/XIPs/pull/132/files#diff-a1647e80caac12654d8e8b8f824d03d83915ba5d6b72098c41f1dd371bbc267c).

#### 📍Where to Start
Start by reviewing the status change in [xip-74-welcome-pointers.md](https://github.com/xmtp/XIPs/pull/132/files#diff-a1647e80caac12654d8e8b8f824d03d83915ba5d6b72098c41f1dd371bbc267c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized ceac03e.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->